### PR TITLE
Corregido mensaje para cliente en la seccion de AgendaDeCitasLaboratorios

### DIFF
--- a/AgendaDeCitas/Consultas/LaboratoriosAgendados.php
+++ b/AgendaDeCitas/Consultas/LaboratoriosAgendados.php
@@ -74,8 +74,19 @@ $query = $conn->query($sql1);
     <td> <?php echo $Usuarios["LabAgendado"]; ?></td>
     <td> <?php echo $Usuarios["Agrego"]; ?></td>
     <td> <?php echo $Usuarios["Asistio"]; ?></td>
-    <td> <a class="btn btn-success"  href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>
-     ! Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕Te invitamos asistir a tu laboratorio: <?php echo $Usuarios["LabAgendado"]; ?> , programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?>  a las <?php echo $Usuarios["Hora"]; ?> en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>*  ¿Confirmamos tu asistencia?  Tu bienestar es nuestra prioridad. ¡Gracias por confiar tu salud con nosotros! 🩷" target="_blank"><span class="fab fa-whatsapp"></span><span class="hidden-xs"></span></a></td>
+    <td>
+    <a class="btn btn-success" href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>! 
+    Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕ 
+    Te invitamos a asistir a tu laboratorio programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?> a las <?php echo $Usuarios["Hora"]; ?> 
+    en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>. 
+    ¿Podrías confirmar tu asistencia? Tu bienestar es nuestra prioridad.
+    Te recordamos leer las recomendaciones en el reverso de tu hoja de laboratorio. 
+    ¡Gracias por confiar en nosotros para cuidar tu salud! 🩷"
+    target="_blank">
+        <span class="fab fa-whatsapp"></span><span class="hidden-xs"></span>
+    </a>
+</td>
+
     <td>
 		 <!-- Basic dropdown -->
 <button class="btn btn-primary dropdown-toggle " type="button" data-toggle="dropdown"

--- a/Enfermeria2/Consultas/LaboratoriosAgendado.php
+++ b/Enfermeria2/Consultas/LaboratoriosAgendado.php
@@ -74,8 +74,18 @@ $query = $conn->query($sql1);
     <td> <?php echo $Usuarios["LabAgendado"]; ?></td>
     <td> <?php echo $Usuarios["Agrego"]; ?></td>
     <td> <?php echo $Usuarios["Asistio"]; ?></td>
-    <td> <a class="btn btn-success"  href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>
-     ! Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕Te invitamos asistir a tu laboratorio: <?php echo $Usuarios["LabAgendado"]; ?> , programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?>  a las <?php echo $Usuarios["Hora"]; ?> en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>*  ¿Confirmamos tu asistencia?  Tu bienestar es nuestra prioridad. ¡Gracias por confiar tu salud con nosotros! 🩷" target="_blank"><span class="fab fa-whatsapp"></span><span class="hidden-xs"></span></a></td>
+    <td>
+    <a class="btn btn-success" href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>! 
+    Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕ 
+    Te invitamos a asistir a tu laboratorio programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?> a las <?php echo $Usuarios["Hora"]; ?> 
+    en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>. 
+    ¿Podrías confirmar tu asistencia? Tu bienestar es nuestra prioridad.
+    Te recordamos leer las recomendaciones en el reverso de tu hoja de laboratorio. 
+    ¡Gracias por confiar en nosotros para cuidar tu salud! 🩷"
+    target="_blank">
+        <span class="fab fa-whatsapp"></span><span class="hidden-xs"></span>
+    </a>
+</td>
     <td>
 		 <!-- Basic dropdown -->
 <button class="btn btn-primary dropdown-toggle " type="button" data-toggle="dropdown"

--- a/POS2/Consultas/LaboratoriosAgendados.php
+++ b/POS2/Consultas/LaboratoriosAgendados.php
@@ -74,8 +74,18 @@ $query = $conn->query($sql1);
     <td> <?php echo $Usuarios["LabAgendado"]; ?></td>
     <td> <?php echo $Usuarios["Agrego"]; ?></td>
     <td> <?php echo $Usuarios["Asistio"]; ?></td>
-    <td> <a class="btn btn-success"  href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>
-     ! Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕Te invitamos asistir a tu laboratorio: <?php echo $Usuarios["LabAgendado"]; ?> , programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?>  a las <?php echo $Usuarios["Hora"]; ?> en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>*  ¿Confirmamos tu asistencia?  Tu bienestar es nuestra prioridad. ¡Gracias por confiar tu salud con nosotros! 🩷" target="_blank"><span class="fab fa-whatsapp"></span><span class="hidden-xs"></span></a></td>
+    <td>
+    <a class="btn btn-success" href="https://api.whatsapp.com/send?phone=+52<?php echo $Usuarios["Telefono"]; ?>&text=¡Hola <?php echo $Usuarios["Nombres_Apellidos"]; ?>! 
+    Queremos recordarte lo importante que es darle seguimiento a tu salud. 👩🏻‍⚕🧑🏻‍⚕ 
+    Te invitamos a asistir a tu laboratorio programado para el día <?php echo fechaCastellano($Usuarios["Fecha"]); ?> a las <?php echo $Usuarios["Hora"]; ?> 
+    en Saluda Centro Médico Familiar <?php echo $Usuarios["Nombre_Sucursal"]; ?>. 
+    ¿Podrías confirmar tu asistencia? Tu bienestar es nuestra prioridad.
+    Te recordamos leer las recomendaciones en el reverso de tu hoja de laboratorio. 
+    ¡Gracias por confiar en nosotros para cuidar tu salud! 🩷"
+    target="_blank">
+        <span class="fab fa-whatsapp"></span><span class="hidden-xs"></span>
+    </a>
+</td>
     <td>
 		 <!-- Basic dropdown -->
 <button class="btn btn-primary dropdown-toggle " type="button" data-toggle="dropdown"


### PR DESCRIPTION
Se solicitó eliminar el laboratorio a realizar del mensaje predefinido de whatsapp, esto para reducir los problemas que se puedan generar al tener laboratorios con nombre demasiado largos, tambien se agregó un mensaje para recordarle al cliente que revise las indicaciones en la parte de atras de la hoja de laboratorio